### PR TITLE
Add non hop-by-hop header option

### DIFF
--- a/transfer-encoding-chunked.js
+++ b/transfer-encoding-chunked.js
@@ -19,7 +19,8 @@
               xhr.onprogress = function() {
                   if (isComplete) return;
 
-                  var isChunked = xhr.getResponseHeader("Transfer-Encoding") === "chunked";
+                  var isChunked = xhr.getResponseHeader("Transfer-Encoding") === "chunked" ||
+                                xhr.getResponseHeader("X-Transfer-Encoding") === "chunked";
                   if (!isChunked) return;
 
                   var response = xhr.response;


### PR DESCRIPTION
"Transfer-Encoding" is a hop-by-hop header (see [here](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Transfer-Encoding) and [here](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers#hop-by-hop_headers)). As a result, it is "meaningful only for a single transport-level connection, and must not be retransmitted by proxies or cached."

This means that when deployed to some cloud providers it is not present in the response header.

This PR would allow users to set a header called "X-Transfer-Encoding" instead that would avoid this issue. It is not a breaking change since the original header is still allowed.